### PR TITLE
Add missing quotes in requireNamespace call

### DIFF
--- a/R/cfunction.R
+++ b/R/cfunction.R
@@ -49,7 +49,7 @@ cfunction <- function(sig=character(), body=character(), includes=character(), o
   }
 
   if (Rcpp) {
-      if (!requireNamespace(Rcpp)) stop("Rcpp cannot be loaded, install it or use the default Rcpp=FALSE")
+      if (!requireNamespace("Rcpp")) stop("Rcpp cannot be loaded, install it or use the default Rcpp=FALSE")
       cxxargs <- c(Rcpp:::RcppCxxFlags(), cxxargs)	# prepend information from Rcpp
   }
   if (length(cppargs) != 0) {


### PR DESCRIPTION
The following happens if the `Rcpp` argument is `TRUE` in `cfunction`:

```
Loading required namespace: TRUE
Failed with error:  ‘there is no package called ‘TRUE’’
```
