### PR TITLE
Use seq_along() instead of seq(along=)

### DIFF
--- a/R/cfunction.R
+++ b/R/cfunction.R
@@ -220,14 +220,14 @@ cfunction <- function(sig=character(), body=character(), includes=character(), o
     ## create .C/.Call function call that will be added to 'fn'
     if (convention == ".Call") {
       body <- quote( CONVENTION("EXTERNALNAME", ARG) )[ c(1:2, rep(3, length(sig[[i]]))) ]
-      for ( j in seq(along = sig[[i]]) ) body[[j+2]] <- as.name(names(sig[[i]])[j])
+      for ( j in seq_along(sig[[i]]) ) body[[j+2]] <- as.name(names(sig[[i]])[j])
     }
     else {
       body <- quote( CONVENTION("EXTERNALNAME", as.logical(ARG), as.integer(ARG),
                     as.double(ARG), as.complex(ARG), as.character(ARG),
           			    as.raw(ARG), as.double(ARG)) )[ c(1:2,types[[i]]+2) ]
       names(body) <- c( NA, "", names(sig[[i]]) )
-      for ( j in seq(along = sig[[i]]) ) body[[j+2]][[2]] <- as.name(names(sig[[i]])[j])
+      for ( j in seq_along(sig[[i]]) ) body[[j+2]][[2]] <- as.name(names(sig[[i]])[j])
 ## OLD VERSION -- does not work for lists of functions
 #      body <- quote( CONVENTION("EXTERNALNAME", as.logical(ARG), as.integer(ARG),
 #                    as.double(ARG), as.complex(ARG), as.character(ARG),

--- a/R/cxxfunction.R
+++ b/R/cxxfunction.R
@@ -166,7 +166,7 @@ extern "C" {
 
     	## create .Call function call that will be added to 'fn'
   		body <- quote( .Call( EXTERNALNAME, ARG) )[ c(1:2, rep(3, length(sig[[i]]))) ]
-  		for ( j in seq(along = sig[[i]]) ) body[[j+2]] <- as.name(names(sig[[i]])[j])
+  		for ( j in seq_along(sig[[i]]) ) body[[j+2]] <- as.name(names(sig[[i]])[j])
 
   		body[[1L]] <- .Call
   		body[[2L]] <- getNativeSymbolInfo( names(sig)[[i]], DLL )$address


### PR DESCRIPTION
#### Summary:

`seq(along=...)` is replaced with `seq_along(...)` in`R/cxxfunction.R` and `R/cfunction.R`.
#### Intended Effect:

No effect on functionality is expected. `seq_along()` may be a bit faster. I just wanted to suppress the warning from `cxxfunction()` in the environment that `options(warnPartialMatchArgs=TRUE)` is set.
