### PR TITLE
Respect BINPREF environment variable

### DIFF
--- a/R/cfunction.R
+++ b/R/cfunction.R
@@ -290,7 +290,11 @@ compileCode <- function(f, code, language, verbose) {
 
   setwd(dirname(libCFile))
   errfile <- paste( basename(libCFile), ".err.txt", sep = "" )
-  cmd <- paste(R.home(component="bin"), "/R CMD SHLIB ", basename(libCFile), " 2> ", errfile, sep="")
+  binpref <- Sys.getenv("BINPREF")
+  cmd <- paste(
+    "BINPREF=", binpref, " ",
+    R.home(component="bin"), "/R CMD SHLIB ", 
+    basename(libCFile), " 2> ", errfile, sep="")
   if (verbose) cat("Compilation argument:\n", cmd, "\n")
   compiled <- system(cmd, intern=!verbose)
   errmsg <- readLines( errfile )


### PR DESCRIPTION
Otherwise R CMD SHLIB does not find my gcc on Windows 32, with Rtools installed on E:

I have the following in .Rprofile to set BINPREF

    Sys.setenv(BINPREF = "E:/Rtools/mingw_32/bin")

I also tested this PR on Linux, where I do not set BINPREF.

Possibly something else involving BINPREF64 would need to be done on 64bit Windows, but I don't have such a system.

(Please do not merge this PR yet, I did not check properly and it does not do the job)