### PR TITLE
use `system2` instead of system

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: inline
-Version: 0.3.16
-Date: 2020-07-11
+Version: 0.3.15
+Date: 2018-05-18
 Title: Functions to Inline C, C++, Fortran Function Calls from R
 Author: Oleg Sklyar, Duncan Murdoch, Mike Smith, Dirk Eddelbuettel, 
  Romain Francois, Karline Soetaert

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: inline
-Version: 0.3.15
-Date: 2018-05-18
+Version: 0.3.16
+Date: 2020-07-11
 Title: Functions to Inline C, C++, Fortran Function Calls from R
 Author: Oleg Sklyar, Duncan Murdoch, Mike Smith, Dirk Eddelbuettel, 
  Romain Francois, Karline Soetaert

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,5 +1,5 @@
 import("methods")
-importFrom("utils", "package.skeleton")
+importFrom("utils", "package.skeleton", "tail")
 
 export(
     "cfunction",

--- a/R/cfunction.R
+++ b/R/cfunction.R
@@ -295,13 +295,13 @@ compileCode <- function(f, code, language, verbose) {
   compiled <- system2(cmd, args = paste(" CMD SHLIB", basename(libCFile)), stderr = errfile)
   errmsg <- readLines( errfile )
   unlink( errfile )
-  writeLines( errmsg )
+  if ( compiled != 0 ) writeLines( errmsg )
   setwd(wd)
 
   if ( !file.exists(libLFile) && file.exists(libLFile2) ) libLFile <- libLFile2
   if ( !file.exists(libLFile) ) {
     cat("\nERROR(s) during compilation: source code errors or compiler configuration errors!\n")
-    system2(cmd, args = paste(" CMD SHLIB --dry-run", basename(libCFile)))
+    if ( !verbose ) system2(cmd, args = paste(" CMD SHLIB --dry-run", basename(libCFile)))
     cat("\nProgram source:\n")
     code <- strsplit(code, "\n")
     for (i in 1:length(code[[1]])) cat(format(i,width=3), ": ", code[[1]][i], "\n", sep="")

--- a/R/cfunction.R
+++ b/R/cfunction.R
@@ -292,7 +292,8 @@ compileCode <- function(f, code, language, verbose) {
   errfile <- paste( basename(libCFile), ".err.txt", sep = "" )
   cmd <- paste0(R.home(component="bin"), "/R")
   if ( verbose ) system2(cmd, args = paste(" CMD SHLIB --dry-run", basename(libCFile)))
-  compiled <- system2(cmd, args = paste(" CMD SHLIB", basename(libCFile)), stderr = errfile)
+  compiled <- system2(cmd, args = paste(" CMD SHLIB", basename(libCFile)),
+                      stdout = FALSE, stderr = errfile)
   errmsg <- readLines( errfile )
   unlink( errfile )
   if ( compiled != 0 ) writeLines( errmsg )

--- a/R/cfunction.R
+++ b/R/cfunction.R
@@ -301,12 +301,12 @@ compileCode <- function(f, code, language, verbose) {
   if ( !file.exists(libLFile) && file.exists(libLFile2) ) libLFile <- libLFile2
   if ( !file.exists(libLFile) ) {
     cat("\nERROR(s) during compilation: source code errors or compiler configuration errors!\n")
-    if ( !verbose ) system2(cmd, args = paste(" CMD SHLIB --dry-run", basename(libCFile)))
+    if ( !verbose ) system2(cmd, args = paste(" CMD SHLIB --dry-run --preclean", basename(libCFile)))
     cat("\nProgram source:\n")
     code <- strsplit(code, "\n")
     for (i in 1:length(code[[1]])) cat(format(i,width=3), ": ", code[[1]][i], "\n", sep="")
     cat("\nCompilation ERROR, function(s)/method(s) not created!\n")
-    if ( nchar(errmsg) > getOption("warning.length") ) stop(tail(errmsg))
+    if ( sum(nchar(errmsg)) > getOption("warning.length") ) stop(tail(errmsg))
     else stop(errmsg)
   }
   return( libLFile )

--- a/R/cfunction.R
+++ b/R/cfunction.R
@@ -292,20 +292,21 @@ compileCode <- function(f, code, language, verbose) {
   errfile <- paste( basename(libCFile), ".err.txt", sep = "" )
   cmd <- paste0(R.home(component="bin"), "/R")
   if ( verbose ) system2(cmd, args = paste(" CMD SHLIB --dry-run", basename(libCFile)))
-  compiled <- system2(cmd, args = paste(" CMD SHLIB", basename(libCFile)), stderr = errfile)
+  compiled <- system2(cmd, args = paste(" CMD SHLIB", basename(libCFile)),
+                      stdout = FALSE, stderr = errfile)
   errmsg <- readLines( errfile )
   unlink( errfile )
-  writeLines( errmsg )
-  setwd(wd)
 
   if ( !file.exists(libLFile) && file.exists(libLFile2) ) libLFile <- libLFile2
   if ( !file.exists(libLFile) ) {
     cat("\nERROR(s) during compilation: source code errors or compiler configuration errors!\n")
-    system2(cmd, args = paste(" CMD SHLIB --dry-run", basename(libCFile)))
+    if ( !verbose ) system2(cmd, args = paste(" CMD SHLIB --dry-run --preclean", basename(libCFile)))
     cat("\nProgram source:\n")
     code <- strsplit(code, "\n")
     for (i in 1:length(code[[1]])) cat(format(i,width=3), ": ", code[[1]][i], "\n", sep="")
-    stop( paste( "Compilation ERROR, function(s)/method(s) not created!", paste( errmsg , collapse = "\n" ) ) )
+    cat("\nCompilation ERROR, function(s)/method(s) not created!\n")
+    if ( sum(nchar(errmsg)) > getOption("warning.length") ) stop(tail(errmsg))
+    else stop(errmsg)
   }
   return( libLFile )
 }

--- a/R/cfunction.R
+++ b/R/cfunction.R
@@ -301,7 +301,11 @@ compileCode <- function(f, code, language, verbose) {
   if ( !file.exists(libLFile) && file.exists(libLFile2) ) libLFile <- libLFile2
   if ( !file.exists(libLFile) ) {
     cat("\nERROR(s) during compilation: source code errors or compiler configuration errors!\n")
-    if ( !verbose ) system2(cmd, args = paste(" CMD SHLIB --dry-run --preclean", basename(libCFile)))
+    if ( !verbose ) {
+      LIBCFILE <- file.path(dirname(libCFile), toupper(basename(libCFile)))
+      file.rename(libCFile, LIBCFILE)
+      system2(cmd, args = paste(" CMD SHLIB --dry-run --preclean", basename(LIBCFILE)))
+    }
     cat("\nProgram source:\n")
     code <- strsplit(code, "\n")
     for (i in 1:length(code[[1]])) cat(format(i,width=3), ": ", code[[1]][i], "\n", sep="")

--- a/R/cfunction.R
+++ b/R/cfunction.R
@@ -290,9 +290,9 @@ compileCode <- function(f, code, language, verbose) {
 
   setwd(dirname(libCFile))
   errfile <- paste( basename(libCFile), ".err.txt", sep = "" )
-  cmd <- paste(R.home(component="bin"), "/R CMD SHLIB ", basename(libCFile), " 2> ", errfile, sep="")
-  if (verbose) cat("Compilation argument:\n", cmd, "\n")
-  compiled <- system(cmd, intern=!verbose)
+  cmd <- paste0(R.home(component="bin"), "/R")
+  if ( verbose ) system2(cmd, args = paste(" CMD SHLIB --dry-run", basename(libCFile)))
+  compiled <- system2(cmd, args = paste(" CMD SHLIB", basename(libCFile)), stderr = errfile)
   errmsg <- readLines( errfile )
   unlink( errfile )
   writeLines( errmsg )
@@ -301,6 +301,7 @@ compileCode <- function(f, code, language, verbose) {
   if ( !file.exists(libLFile) && file.exists(libLFile2) ) libLFile <- libLFile2
   if ( !file.exists(libLFile) ) {
     cat("\nERROR(s) during compilation: source code errors or compiler configuration errors!\n")
+    system2(cmd, args = paste(" CMD SHLIB --dry-run", basename(libCFile)))
     cat("\nProgram source:\n")
     code <- strsplit(code, "\n")
     for (i in 1:length(code[[1]])) cat(format(i,width=3), ": ", code[[1]][i], "\n", sep="")

--- a/R/cfunction.R
+++ b/R/cfunction.R
@@ -296,7 +296,6 @@ compileCode <- function(f, code, language, verbose) {
                       stdout = FALSE, stderr = errfile)
   errmsg <- readLines( errfile )
   unlink( errfile )
-  if ( compiled != 0 ) writeLines( errmsg )
   setwd(wd)
 
   if ( !file.exists(libLFile) && file.exists(libLFile2) ) libLFile <- libLFile2
@@ -306,7 +305,9 @@ compileCode <- function(f, code, language, verbose) {
     cat("\nProgram source:\n")
     code <- strsplit(code, "\n")
     for (i in 1:length(code[[1]])) cat(format(i,width=3), ": ", code[[1]][i], "\n", sep="")
-    stop( paste( "Compilation ERROR, function(s)/method(s) not created!", paste( errmsg , collapse = "\n" ) ) )
+    cat("\nCompilation ERROR, function(s)/method(s) not created!\n")
+    if ( nchar(errmsg) > getOption("warning.length") ) stop(tail(errmsg))
+    else stop(errmsg)
   }
   return( libLFile )
 }

--- a/R/cfunction.R
+++ b/R/cfunction.R
@@ -296,16 +296,11 @@ compileCode <- function(f, code, language, verbose) {
                       stdout = FALSE, stderr = errfile)
   errmsg <- readLines( errfile )
   unlink( errfile )
-  setwd(wd)
 
   if ( !file.exists(libLFile) && file.exists(libLFile2) ) libLFile <- libLFile2
-  if ( !file.exists(libLFile) ) {
+  if ( !file.exists(libLFile) )
     cat("\nERROR(s) during compilation: source code errors or compiler configuration errors!\n")
-    if ( !verbose ) {
-      LIBCFILE <- file.path(dirname(libCFile), toupper(basename(libCFile)))
-      file.rename(libCFile, LIBCFILE)
-      system2(cmd, args = paste(" CMD SHLIB --dry-run --preclean", basename(LIBCFILE)))
-    }
+    if ( !verbose ) system2(cmd, args = paste(" CMD SHLIB --dry-run --preclean", basename(libCFile)))
     cat("\nProgram source:\n")
     code <- strsplit(code, "\n")
     for (i in 1:length(code[[1]])) cat(format(i,width=3), ": ", code[[1]][i], "\n", sep="")

--- a/R/cfunction.R
+++ b/R/cfunction.R
@@ -298,7 +298,7 @@ compileCode <- function(f, code, language, verbose) {
   unlink( errfile )
 
   if ( !file.exists(libLFile) && file.exists(libLFile2) ) libLFile <- libLFile2
-  if ( !file.exists(libLFile) )
+  if ( !file.exists(libLFile) ) {
     cat("\nERROR(s) during compilation: source code errors or compiler configuration errors!\n")
     if ( !verbose ) system2(cmd, args = paste(" CMD SHLIB --dry-run --preclean", basename(libCFile)))
     cat("\nProgram source:\n")


### PR DESCRIPTION
084dbdd is the the commit that actually changes to using the more portable `system2` rather than the older `system`, which fixes #11.  The rest of the commits were just me flailing around trying to get the error / verbosity reporting to be reasonable in more situations. You might have a different definition of reasonable, but I think the main two things were:

- Show what `make` would do by calling `R CMD SHLIB` with `--dry-run` if `verbose = TRUE` or if there was an error
- Show the end of the error message if it is too long to be printed in its entirety. R has an `option()` for this, but by default it is 10000 lines I think. Unfortunately, it is pretty common to have more than 10000 lines of unhelpful compiler warnings if using headers from BH or especially RcppEigen. So, if you feed the whole error file into `stop`, it would only show the first 10000 compiler warnings rather than the text of the actual compiler error. Now, it is feeding `tail(errmsg)` to `stop` when it exceeds the line limit, so you at least see the compiler error rather than the compiler warnings.

I ran `revdepcheck::revdep_check` under r-devel on Debian. mkin, RxODE, and themetagenomics have errors with inline on CRAN that are still errors with this PR but nothing got worse. I also ran it on Windows and didn't encounter any additional problems other than a couple packages were too complicated to install from source. Someone else ran it on Mac and said there were no additional problems. Other people have been installing my branch from GitHub and using it with RStan, so I think it is solid.

The `system2` function has an `env` argument that you might want to use to set the environmental variables rather than setting them in `cxxfunction`, but I didn't touch that.