### PR TITLE
Multiple minor CRAN check-related updates

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
 debian
 \.travis\.yml
 .*\.tar\.gz
+\.github

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/local
+*.tar.gz
+*.Rcheck
+*~

--- a/R/cfunction.R
+++ b/R/cfunction.R
@@ -56,7 +56,9 @@ cfunction <- function(sig=character(), body=character(), includes=character(), o
   if (Rcpp) {
       if (!requireNamespace("Rcpp", quietly=TRUE))
           stop("Rcpp cannot be loaded, install it or use the default Rcpp=FALSE", call.=FALSE)
-      cxxargs <- c(Rcpp:::RcppCxxFlags(), cxxargs)	# prepend information from Rcpp
+      rcppdir <- system.file("include", package="Rcpp")
+      if (.Platform$OS.type == "windows") rcppdir <- utils::shortPathName(normalizePath(rcppdir))
+      cxxargs <- c(paste("-I", rcppdir, sep=""), cxxargs)	# prepend information from Rcpp
   }
   if (length(cppargs) != 0) {
       args <- paste(cppargs, collapse=" ")


### PR DESCRIPTION
Just trying to lend a hand here. And checking a package is really fun using rcc.r!

This just adds `.github` to `.Rbuildignore`

I also get another note:

```
N  checking dependencies in R code (340ms)
   Unexported object imported by a ':::' call: ‘Rcpp:::RcppCxxFlags’
     See the note in ?`:::` about the use of this operator.
```

I don't understand why this does not show up on the CRAN check page. Anyways I would leave this one for you.