### PR TITLE
Fix two bugs and add corresponding tests

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -43,7 +43,7 @@ setMethod("moveDLL",
     environment(x)$libLFile <- new_path
 
     # Adjust the symbol info in the function body
-    function_name <- environment(x)$f
+    function_name <- environment(x)$name
     body(x)[[2]] <- getNativeSymbolInfo(function_name, new_dll_info[["name"]])$address
 
     invisible(new_dll_info)
@@ -62,14 +62,19 @@ readCFunc <- function(file) {
   x <- readRDS(file)
   if (class(x) != "CFunc") stop(file, " does not contain a serialized CFunc object")
 
+  # Get code for restoring after updating the function body
+  source_code <- x@code
+
   # Load the DLL
   env <- environment(x)
   dll_info <- dyn.load(env$libLFile)
 
   # Set the symbol info in the function body
-  body(x)[[2]] <- getNativeSymbolInfo(env$f, dll_info[["name"]])$address
+  body(x)[[2]] <- getNativeSymbolInfo(env$name, dll_info[["name"]])[["address"]]
+  x_cf <- as(x, "CFunc")
+  x_cf@code <- source_code
   
-  return(x)
+  return(x_cf)
 }
 
 setGeneric("code", function(x, ...) standardGeneric("code") )

--- a/inst/tinytest/test_utilities.R
+++ b/inst/tinytest/test_utilities.R
@@ -68,4 +68,14 @@ moveDLL(quadfn, name = "testname", directory = tempdir(), unload = TRUE,
   overwrite = TRUE)
 writeCFunc(quadfn, quadfn_path)
 quadfn_reloaded <- readCFunc(quadfn_path)
-expect_identical(quadfn_reloaded(5, 1:5), res_known)
+
+# Create a function with a user defined function name in the source code,
+# save and restore
+quadfn_named <- cfunction(signature(n = "integer", x = "numeric"), code,
+  language = "C", convention = ".C", name = "quadfn")
+moveDLL(quadfn_named, name = "quadfn_dll", directory = tempdir(), unload = TRUE,
+  overwrite = TRUE)
+writeCFunc(quadfn_named, quadfn_path)
+quadfn_named_reloaded <- readCFunc(quadfn_path)
+expect_identical(quadfn_named_reloaded(5, 1:5), res_known)
+expect_true(grepl("quadfn", quadfn_named_reloaded@code))


### PR DESCRIPTION
- The first one prevented correctly moving a DLL in case the function
  in the source code had been given a user specified name.
- readCFunc did not return a CFunc object as restoring the pointer
  after reading downgraded the object to a regular function. Now
  readCFunc obtains the code before restoring the pointer,
  coerces the function to a CFunc object afterwards and restores
  the content of the code slot.