### PR TITLE
Test failures, fixes #21

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: inline
-Version: 0.3.18
+Version: 0.3.17.1
 Date: 2021-05-17
 Title: Functions to Inline C, C++, Fortran Function Calls from R
 Author: Oleg Sklyar, Duncan Murdoch, Mike Smith, Dirk Eddelbuettel, 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: inline
-Version: 0.3.17
-Date: 2020-11-30
+Version: 0.3.18
+Date: 2021-05-17
 Title: Functions to Inline C, C++, Fortran Function Calls from R
 Author: Oleg Sklyar, Duncan Murdoch, Mike Smith, Dirk Eddelbuettel, 
  Romain Francois, Karline Soetaert, Johannes Ranke

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -9,8 +9,8 @@ setMethod("moveDLL",
   function(x, name, directory, unload = FALSE, overwrite = FALSE, verbose = FALSE) {
 
     # Check arguments
-    if (length(name) > 1) stop("Please only supply only one name")
-    if (length(directory) > 1) stop("Please only supply only one directory name")
+    if (length(name) > 1) stop("Please supply only one name")
+    if (length(directory) > 1) stop("Please supply only one directory name")
 
     # Obtain path to DLL
     old_path <- environment(x)$libLFile
@@ -43,10 +43,6 @@ setMethod("moveDLL",
 
     # Adjust the path that getDynLib uses
     environment(x)$libLFile <- new_path
-
-    # Adjust the symbol info in the function body
-    function_name <- environment(x)$name
-    body(x)[[2]] <- getNativeSymbolInfo(function_name, new_dll_info[["name"]])$address
 
     invisible(new_dll_info)
   }

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -37,14 +37,10 @@ setMethod("moveDLL",
     if (!copy_success) stop("Failed to copy DLL from ", old_path, " to ", new_path)
     if (verbose) message("Copied DLL from ", old_path, " to ", new_path)
 
-    # Unload DLL and reload from its new location
-    dyn.unload(old_path)
-    new_dll_info <- dyn.load(new_path)
-
     # Adjust the path that getDynLib uses
     environment(x)$libLFile <- new_path
 
-    invisible(new_dll_info)
+    invisible()
   }
 )
 

--- a/inst/tinytest/test_utilities.R
+++ b/inst/tinytest/test_utilities.R
@@ -29,10 +29,6 @@ moveDLL(quadfn, name = "testname", directory = tempdir())
 expect_identical(quadfn(5, 1:5), res_known)
 
 expect_error(
-  moveDLL(quadfn, name = "testname", directory = tempdir()),
-  "DLL .* in use")
-
-expect_error(
   moveDLL(quadfn, name = "testname", directory = tempdir(), unload = TRUE),
   "Failed to copy")
 
@@ -68,6 +64,8 @@ moveDLL(quadfn, name = "testname", directory = tempdir(), unload = TRUE,
   overwrite = TRUE)
 writeCFunc(quadfn, quadfn_path)
 quadfn_reloaded <- readCFunc(quadfn_path)
+expect_identical(quadfn_reloaded(5, 1:5), res_known)
+
 
 # Create a function with a user defined function name in the source code,
 # save and restore


### PR DESCRIPTION
This PR removes some code that turned out to be unnecessary (unloading and reloading the DLL in 'moveDLL'), and which does not work with current R-devel, presumably due svn commit r80285 addressing [PR#16446](https://bugs.r-project.org/bugzilla/show_bug.cgi?id=16446). The commit message contains the phrase "Zero external pointers of native symbols of unloaded DLLs", and I do observe that unloading the DLL in moveDLL removes the pointer with current R-devel. So with this commit we do not unload the old DLL any more in 'moveDLL'. The only unloading that takes place now is in case a DLL is already loaded from the target location of 'moveDLL'.

I tested this locally with R 4.0.5 and current R-devel on Linux, as well as on r-hub (Windows, Ubuntu gcc and Fedora clang), all went well. I also uploaded to winbuilder - Dirk, you have probably received the e-mail.
I also tested 'mkin' which makes use of 'moveDLL', everything appears to be fine. I am not aware that any other packages use 'moveDLL' but we may still want to do reverse dependency checks before uploading. I have never needed to do this, so I do not have a workflow for it.