### PR TITLE
Improve display of error messages in `compileCode`

### DIFF
--- a/R/cfunction.R
+++ b/R/cfunction.R
@@ -292,7 +292,7 @@ compileCode <- function(f, code, language, verbose) {
   if ( verbose ) system2(cmd, args = paste(" CMD SHLIB --dry-run", basename(libCFile)))
   compiled <- system2(cmd, args = paste(" CMD SHLIB", basename(libCFile)),
                       stdout = FALSE, stderr = errfile)
-  errmsg <- readLines( errfile )
+  errmsg <- paste0(readLines(errfile), collapse = "\n")
   unlink( errfile )
 
   if ( !file.exists(libLFile) ) {
@@ -302,8 +302,10 @@ compileCode <- function(f, code, language, verbose) {
     code <- strsplit(code, "\n")
     for (i in 1:length(code[[1]])) cat(format(i,width=3), ": ", code[[1]][i], "\n", sep="")
     cat("\nCompilation ERROR, function(s)/method(s) not created!\n")
-    if ( sum(nchar(errmsg)) > getOption("warning.length") ) stop(tail(errmsg))
-    else stop(errmsg)
+    if ( nchar(errmsg) > getOption("warning.length") ) {
+      stop(substr(errmsg, start = nchar(errmsg) - getOption("warning.length") + 1,
+                  stop = nchar(errmsg)))
+    } else stop(errmsg)
   }
   return( libLFile )
 }


### PR DESCRIPTION
Hi, thanks for this package, it is very useful!
When using it, I had the impression that the compilation errors (at least for C++) lost the formatting between the output of the compiler and the error message in R.

For example, the code
```r
test_1 <- inline::cxxfunction(
  signature(y = "numeric"),
  ' return (y +  ;  ' ,
  plugin = "Rcpp"
)
```
is obviously wrong, but gives the following difficult-to-read error message
`
file3ae46e181323.cpp: In function 'SEXPREC* file3ae46e181323(SEXP)':file3ae46e181323.cpp:28:15: error: expected primary-expression before ';' token   28 |  return (y +  ;      |               ^file3ae46e181323.cpp:28:13: error: expected ')' before ';' token   28 |  return (y +  ;      |         ~   ^ ~      |             )make: *** [C:/PROGRA~1/R/R-42~1.2/etc/x64/Makeconf:260: file3ae46e181323.o] Error 1
`

With this PR, the error message is formatted as expected:
```
  file12e065837a53.cpp: In function 'SEXPREC* file12e065837a53(SEXP)':
file12e065837a53.cpp:28:15: error: expected primary-expression before ';' token
   28 |  return (y +  ;
      |               ^
file12e065837a53.cpp:28:13: error: expected ')' before ';' token
   28 |  return (y +  ;
      |         ~   ^ ~
      |             )
make: *** [C:/PROGRA~1/R/R-42~1.2/etc/x64/Makeconf:260: file12e065837a53.o] Error 1
```
